### PR TITLE
Cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ os: osx
 osx_image: beta-xcode6.1
 
 env:
+  matrix:
+    
+    - CONDA_PY=27
+    - CONDA_PY=34
+    - CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "vBeDQzWXflVYWFF5/Fx1ffVvG187iwaQ+edV22w4ZNAIiEIZhCoJIGcwwB62hldoNwOT6j6obdhR7Wmb+PjyhNYxqYhe++Djk5cxbsYUMR1ZUFcdHDvAiuKErY4zPbNWWZD6vpTuySaK+8ye3CeqhItjMU052YhpJWXAtbcImD97t/B5ttLeYwPLJGyof/6mJyaybROhatpBA0UZHIZa75YD4W60Y48ejCIVvZ8rNoRnUGjvFxfnVJmaemRSnlcSPypOgCoenOofBpxL5USyz1wzLy5kyVjWGl7pyQcCRGptOe3DXZJtijyvmk+p0T/eqzL2cqRJRB85m+WyYlHdRu2h2YJfxf9khKXNLEF9gumPkz/1G8hvk/Nr80E4zn23y7f3x9SRwSKZm3h8DzTNIqI3zRv7F2//gTDucJRPnA9elYszSJ2oqgLNtnX8O2dek00vpQ7NOWLbYyZpkDorr/654v97VYwMbtQ4jfNnmUNta+VbIao68xCXJ3ajiicdy4XmlrRCeEajycLSqRmk+Q1NmWobN1ZJEWutk5G/LctR7Y8WP7/mqWrLdbsnUp1zIzXh6iRL3dKYmQzK/u0OumXFDk9BWpnsvjFLQ4+goa57yuqBQI5IRRo064n8I92AFRkFVhEuXJVTc1RrDNqBYh5eMaEfWDNmuLf7j+qYS24="

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Statistical learning for neuroimaging in Python
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/nilearn-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/nilearn-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/nilearn-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/nilearn-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/nilearn-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/nilearn-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nilearn/badges/version.svg)](https://anaconda.org/conda-forge/nilearn)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nilearn/badges/downloads.svg)](https://anaconda.org/conda-forge/nilearn)
+
 Installing nilearn
 ==================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `nilearn` available on your platfo
 ```
 conda search nilearn --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/nilearn-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/nilearn-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/nilearn-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/nilearn-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/nilearn-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/nilearn-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nilearn/badges/version.svg)](https://anaconda.org/conda-forge/nilearn)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/nilearn/badges/downloads.svg)](https://anaconda.org/conda-forge/nilearn)
 
 
 Updating nilearn-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,24 +4,39 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
+      CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -42,24 +57,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,22 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 1 case(s).
+# Embarking on 3 case(s).
+    set -x
+    export CONDA_PY=27
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=34
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=35
+    set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: nilearn-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/n/nilearn/nilearn-{{ version }}.tar.gz
-  md5: 383d406d2eeec2bf7b68cc5d4fe20cb9
+  sha256: 6937a6c0aa83a65028532cbdb623bb53b8df569e6c3bb19308d78b5ef2cfb3d2
 
 build:
     number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     number: 1
-    script: python setup.py install --single-version-externally-managed --record record.txt
+    script: python -B setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,8 @@ about:
   license: BSD 3-clause
   license_family: BSD
   summary: Statistical learning for neuroimaging in Python
+  dev_url: https://github.com/nilearn/nilearn
+  doc_url: https://nilearn.github.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: nilearn-{{ version }}.tar.gz
-  url: https://files.pythonhosted.org/packages/source/n/nilearn/nilearn-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/n/nilearn/nilearn-{{ version }}.tar.gz
   md5: 383d406d2eeec2bf7b68cc5d4fe20cb9
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6937a6c0aa83a65028532cbdb623bb53b8df569e6c3bb19308d78b5ef2cfb3d2
 
 build:
-    number: 1
+    number: 2
     script: python -B setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ test:
 about:
   home: https://nilearn.github.io
   license: BSD 3-clause
+  license_family: BSD
   summary: Statistical learning for neuroimaging in Python
 
 extra:


### PR DESCRIPTION
Closes https://github.com/conda-forge/nilearn-feedstock/pull/11

Uses the existing re-rendering from PR ( https://github.com/conda-forge/nilearn-feedstock/pull/11 ). Drops requirements from build dependencies that don't appear to be needed for the build explicitly. Switches to pypi.io for source acquisition and uses the sha256 checksum. Finally fills in some more metadata (haven't included the `description`).